### PR TITLE
Add proper state manager for agent

### DIFF
--- a/config.sample.js
+++ b/config.sample.js
@@ -17,7 +17,7 @@ module.exports = {
     sampleRate: 16000,
     voiceSettings: {
       stability: 0.2, // default is 50
-      similarity_boost: 0.8, // default is 80
+      similarity_boost: 0.8, // default is 80,
     },
   },
   playHT: {

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "Node16",
+    "module": "CommonJS",
     "target": "ES2022",
     "checkJs": false /* Typecheck .js files. */,
     "lib": ["ES2022"]

--- a/src/extension.js
+++ b/src/extension.js
@@ -13,15 +13,15 @@ let statusBarItem = null;
 function activate(context) {
   console.log('Choo choo 🚂!');
 
-  const commandLoader = new CommandLoader(context);
-  commandLoader.load('commands');
-
   statusBarItem = vscode.window.createStatusBarItem(
     vscode.StatusBarAlignment.Left,
     -1000
   );
   statusBarItem.show();
   context.subscriptions.push(statusBarItem);
+
+  const commandLoader = new CommandLoader(context);
+  commandLoader.load('commands');
 
   setStatusbarText('$(circle-slash) Awaiting input');
 }

--- a/src/lib/agent/Agent.js
+++ b/src/lib/agent/Agent.js
@@ -1,4 +1,4 @@
-const StateMachine = require('../../util/statemachine/stateMachine');
+const StateMachine = require('../../util/statemachine/StateMachine');
 const { SocketServer } = require('../web/webserver');
 const { applyDiffs } = require('../../util/realisticTyping');
 const vscode = require('vscode');

--- a/src/lib/agent/states/IdleState.js
+++ b/src/lib/agent/states/IdleState.js
@@ -1,0 +1,11 @@
+const { setStatusbarText } = require('../../../extension');
+const State = require('../../../util/statemachine/state');
+
+class IdleState extends State {
+  onActivate() {
+    setStatusbarText('$(circle-slash) Awaiting input');
+    this.stateMachine.webserver.sendStatus('pending'); // state machine is our agent in this case
+  }
+}
+
+module.exports = IdleState;

--- a/src/lib/agent/states/IdleState.js
+++ b/src/lib/agent/states/IdleState.js
@@ -1,5 +1,5 @@
 const { setStatusbarText } = require('../../../extension');
-const State = require('../../../util/statemachine/state');
+const State = require('../../../util/statemachine/State');
 
 class IdleState extends State {
   onActivate() {

--- a/src/lib/agent/states/promptingState.js
+++ b/src/lib/agent/states/promptingState.js
@@ -1,5 +1,5 @@
 const { setStatusbarText } = require('../../../extension');
-const State = require('../../../util/statemachine/state');
+const State = require('../../../util/statemachine/State');
 
 class PromptingState extends State {
   onActivate() {

--- a/src/lib/agent/states/promptingState.js
+++ b/src/lib/agent/states/promptingState.js
@@ -1,0 +1,11 @@
+const { setStatusbarText } = require('../../../extension');
+const State = require('../../../util/statemachine/state');
+
+class PromptingState extends State {
+  onActivate() {
+    setStatusbarText('$(loading~spin) Prompting model...');
+    this.stateMachine.webserver.sendStatus('thinking'); // state machine is our agent in this case
+  }
+}
+
+module.exports = PromptingState;

--- a/src/lib/agent/states/talkingState.js
+++ b/src/lib/agent/states/talkingState.js
@@ -1,5 +1,5 @@
 const { setStatusbarText } = require('../../../extension');
-const State = require('../../../util/statemachine/state');
+const State = require('../../../util/statemachine/State');
 
 class TalkingState extends State {
   onActivate() {

--- a/src/lib/agent/states/talkingState.js
+++ b/src/lib/agent/states/talkingState.js
@@ -1,0 +1,11 @@
+const { setStatusbarText } = require('../../../extension');
+const State = require('../../../util/statemachine/state');
+
+class TalkingState extends State {
+  onActivate() {
+    setStatusbarText('$(mic) Talking...');
+    this.stateMachine.webserver.sendStatus('talking'); // state machine is our agent in this case
+  }
+}
+
+module.exports = TalkingState;

--- a/src/lib/agent/states/thinkingState.js
+++ b/src/lib/agent/states/thinkingState.js
@@ -1,5 +1,5 @@
 const { setStatusbarText } = require('../../../extension');
-const State = require('../../../util/statemachine/state');
+const State = require('../../../util/statemachine/State');
 
 class ThinkingState extends State {
   onActivate() {

--- a/src/lib/agent/states/thinkingState.js
+++ b/src/lib/agent/states/thinkingState.js
@@ -1,0 +1,11 @@
+const { setStatusbarText } = require('../../../extension');
+const State = require('../../../util/statemachine/state');
+
+class ThinkingState extends State {
+  onActivate() {
+    setStatusbarText('$(loading~spin) waiting for chunks...');
+    this.stateMachine.webserver.sendStatus('thinking'); // state machine is our agent in this case
+  }
+}
+
+module.exports = ThinkingState;

--- a/src/lib/agent/states/writingState.js
+++ b/src/lib/agent/states/writingState.js
@@ -1,5 +1,5 @@
 const { setStatusbarText } = require('../../../extension');
-const State = require('../../../util/statemachine/state');
+const State = require('../../../util/statemachine/State');
 
 class WritingState extends State {
   onActivate() {

--- a/src/lib/agent/states/writingState.js
+++ b/src/lib/agent/states/writingState.js
@@ -1,0 +1,11 @@
+const { setStatusbarText } = require('../../../extension');
+const State = require('../../../util/statemachine/state');
+
+class WritingState extends State {
+  onActivate() {
+    setStatusbarText('$(record-keys) Writing code...');
+    this.stateMachine.webserver.sendStatus('writing'); // state machine is our agent in this case
+  }
+}
+
+module.exports = WritingState;

--- a/src/util/statemachine/state.js
+++ b/src/util/statemachine/state.js
@@ -1,0 +1,36 @@
+/** @abstract */
+class State {
+  constructor(stateMachine) {
+    this.stateMachine = stateMachine;
+  }
+
+  activate() {
+    if (this.isActive) return;
+    this.isActive = true;
+
+    this.onPreActivate();
+    this.onActivate();
+  }
+
+  deactivate() {
+    if (!this.isActive) return;
+    this.onPreDeactivate();
+    this.onDeactivate();
+    this.onLateDeactivate();
+    this.isActive = false;
+  }
+
+  onPreActivate() {}
+
+  /** @abstract */
+  onActivate() {}
+
+  onPreDeactivate() {}
+
+  /** @abstract */
+  onDeactivate() {}
+
+  onLateDeactivate() {}
+}
+
+module.exports = State;

--- a/src/util/statemachine/stateMachine.js
+++ b/src/util/statemachine/stateMachine.js
@@ -1,4 +1,4 @@
-const State = require('./state');
+const State = require('./State');
 
 class StateMachine extends State {
   constructor() {

--- a/src/util/statemachine/stateMachine.js
+++ b/src/util/statemachine/stateMachine.js
@@ -1,0 +1,46 @@
+const State = require('./state');
+
+class StateMachine extends State {
+  constructor() {
+    super();
+    this.states = [];
+
+    /** @type {State} */
+    this.activeState = null;
+  }
+
+  /**
+   * Add a state to the state machine
+   * @param {State} state
+   */
+  addState(state) {
+    if (!(state instanceof State)) {
+      throw new Error('StateMachine: State must be an instance of State');
+    }
+
+    state.stateMachine = this;
+    this.states.push(state);
+  }
+
+  /**
+   * Switch the active state to a new state
+   * @param {String} stateName The name of the state to go to
+   */
+  goToState(stateName) {
+    const state = this.states.find(
+      (s) =>
+        s.constructor.name.toLowerCase().replace('state', '') ===
+        stateName.toLowerCase()
+    );
+    if (!state) throw new Error(`StateMachine: State ${stateName} not found`);
+
+    if (this.activeState !== null) {
+      this.activeState.deactivate();
+    }
+
+    this.activeState = state;
+    this.activeState.activate();
+  }
+}
+
+module.exports = StateMachine;


### PR DESCRIPTION
This PR features the following:
- A (technically) abstract class `src/util/statemachine/State.js` that is used for classes that can be a type of state.
- `src/util/statemachine/StateMachine.js` which handles storing state for a class that extends it. This is used by our `Agent.js` to keep track of its state
- `src/lib/agent/states/*` state files for each state the agent has. All actions that have to be executed when this state is activated are located in the `onActivate()` method. You can see what methods are supported by looking in the `State.js` abstract class.
- Modified the `Agent.js` file to use the new state manager and move some stuff to the appropriate state.
- Added a new "thinking" state which get's set when the agent is waiting for new chunks to come in from the LLM